### PR TITLE
Removed Telegram and email notification setup from install routine.

### DIFF
--- a/config.php.template
+++ b/config.php.template
@@ -31,26 +31,10 @@ define("POLICY_MAIL", "##policy_mail##"); //contact email in policy
 define("POLICY_PHONE", "##policy_phone##");
 define("WHO_WE_ARE","##who_we_are##");
 define("POLICY_URL","##policy_url##");
-define('SUBSCRIBE_EMAIL', true);
-define('SUBSCRIBE_TELEGRAM', false);
-define("TG_BOT_API_TOKEN", "##tg_bot_token##"); //Telegram Bot Token
-define("TG_BOT_USERNAME", "##tg_bot_username##"); //Telegram Bot username
 define("INSTALL_OVERRIDE", false);
 define("DEFAULT_LANGUAGE", "en_GB");
-define("GOOGLE_RECAPTCHA", false);
-define("GOOGLE_RECAPTCHA_SITEKEY", "##google_site_key##");
-define("GOOGLE_RECAPTCHA_SECRET", "##google_secret##");
-define("PHP_MAILER", false);  // Enable if we are to use extenral PHPMailer() library
-define("PHP_MAILER_PATH", "##phpmailer_path##"); // Path to src folder of PHPMailer() library - without ending /
-define("PHP_MAILER_SMTP", false); // Set to true if we are to use SMTP
-define("PHP_MAILER_HOST", "##phpmailer_host##");  // SMTP host
-define("PHP_MAILER_PORT", "##phpmailer_port##");  // SMTP Port
-define("PHP_MAILER_SECURE", ""); // Set to TLS or SSL or leave blank for plaintext
-define("PHP_MAILER_USER", "##phpmailer_user##");  // SMTP Authentication user
-define("PHP_MAILER_PASS", "##phpmailer_pass##");  // SMTP authenticatin password
 define("CUSTOM_LOGO_URL",""); // This will use the default logo if left empty
 define("COPYRIGHT_TEXT",""); // Leave this empty if you don't want your copyright displayed
-define("CRON_SERVER_IP",""); // IP Address that will be used to call cron task. Leave empty if not used!
 // Without COPYRIGHT_TEXT Set
 // 2020 Server Status Project Contributors
 // With COPYRIGHT_TEXT Set

--- a/install.php
+++ b/install.php
@@ -6,8 +6,6 @@ define("MINIMUM_PHP_VERSION", "5.4.0");
 define("POLICY_URL", "policy.php"); //Default policy URL
 define("CUSTOM_LOGO_URL","");
 define("COPYRIGHT_TEXT","");
-define('SUBSCRIBE_EMAIL', false);
-define('SUBSCRIBE_TELEGRAM', false);
 require_once("classes/locale-negotiator.php");
 require_once("classes/db-class.php");
 
@@ -141,9 +139,7 @@ if(isset($_POST['server']) && empty($message))
 		$config = str_replace("##who_we_are##", htmlspecialchars($_POST['who_we_are'], ENT_QUOTES), $config);
 		$policy_url_conf = ( ! empty($_POST['policy_url']) ) ? htmlspecialchars($_POST['policy_url'], ENT_QUOTES) : $_POST['url']."/policy.php";
 		$config = str_replace("##policy_url##", $policy_url_conf, $config);
-		$config = str_replace("##tg_bot_token##", htmlspecialchars($_POST['tgtoken'], ENT_QUOTES), $config);
-		$config = str_replace("##tg_bot_username##", htmlspecialchars($_POST['tgbot'], ENT_QUOTES), $config);
-
+		
 		file_put_contents("config.php", $config);
 
 		include_once "create-server-config.php";
@@ -245,15 +241,6 @@ if (!empty($message))
 		<div class="form-group clearfix">
 			<div class="col-sm-6"><label for="dbuser"><?php echo _("User");?>: </label><input type="text" name="dbuser" value="<?php echo ((isset($_POST['dbuser']))?htmlspecialchars($_POST['dbuser'], ENT_QUOTES):'');?>" id="dbuser" placeholder="<?php echo _("User");?>" class="form-control" required></div>
 			<div class="col-sm-6"><label for="dbpassword"><?php echo _("Password");?>: </label><input type="password" name="dbpassword" value="<?php echo ((isset($_POST['dbpassword']))?htmlspecialchars($_POST['dbpassword'], ENT_QUOTES):'');?>" id="dbpassword" placeholder="<?php echo _("Password");?>" class="form-control" required></div>
-		</div>
-	</section>
-	<section class="install-section clearfix">
-		<h2><?php echo _("Telegram");?></h2>
-		<summary><?php echo _("You can provide a subscription feature through telegram.");?></summary>
-
-		<div class="form-group clearfix">
-			<div class="col-sm-6"><label for="tgtoken"><?php echo _("Telegram bot API Token");?>: </label><input type="text" name="tgtoken" value="<?php echo ((isset($_POST['tgtoken']))?htmlspecialchars($_POST['tgtoken'], ENT_QUOTES):'');?>" id="tgtoken" placeholder="<?php echo _("Telegram Bot API Token");?>" class="form-control"></div>
-			<div class="col-sm-6"><label for="tgbot"><?php echo _("Telegram Bot Username");?>: </label><input type="text" name="tgbot" value="<?php echo ((isset($_POST['tgbot']))?htmlspecialchars($_POST['tgbot'], ENT_QUOTES):'');?>" id="tgbot" placeholder="<?php echo _("Telegram Bot Username");?>" class="form-control"></div>
 		</div>
 	</section>
 	<section class="install-section clearfix">


### PR DESCRIPTION
In prepearing to move the config.php options to db options, the following config
options have been removed from config.php

- SUBSCRIBE_TELEGRAM
- SUBSCRIBE_EMAIL
- TG_BOT_API_TOKEN
- TG_BOT_USERNAME
- GOOGLE_RECAPTCHA
- GOOGLE_RECAPTCHA_SITEKEY
- GOOGLE_RECAPTCHA_SECRET
- PHP_MAILER
- PHP_MAILER_PATH
- PHP_MAILER_SMTP
- PHP_MAILER_HOST
- PHP_MAILER_PORT
- PHP_MAILER_SECURE
- PHP_MAILER_USER
- PHP_MAILER_PASS
- CRON_SERVER_IP